### PR TITLE
* #23: renamed secure parameter to usetls to make it more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-driver-go&metric=code_smells)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-driver-go)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=com.exasol%3Aexasol-driver-go&metric=coverage)](https://sonarcloud.io/dashboard?id=com.exasol%3Aexasol-driver-go)
 
-
 This repository contains a Go library for connection to the [Exasol](https://www.exasol.com/) database.
 
 This library uses the standard Golang [SQL driver interface](https://golang.org/pkg/database/sql/) for easy use.
@@ -16,24 +15,9 @@ This library uses the standard Golang [SQL driver interface](https://golang.org/
 
 ### Create Connection
 
-#### With Exasol DSN
-
-```go
-package main
-
-import (
-	"database/sql"
-	
-	_ "github.com/exasol/exasol-driver-go"
-)
-
-func main() {
-	database, err := sql.Open("exasol", "exa:<host>:<port>;user=<username>;password=<password>")
-	...
-}
-```
-
 #### With Exasol Config
+
+We recommend using a provided builder to build a connection string:
 
 ```go
 package main
@@ -46,6 +30,25 @@ import (
 
 func main() {
 	database, err := sql.Open("exasol", exasol.NewConfig("<username>", "<password>").Port(<port>).Host("<host>").String())
+	...
+}
+```
+
+#### With Exasol DSN
+
+There is also a way to build the connection string without the builder:
+
+```go
+package main
+
+import (
+	"database/sql"
+	
+	_ "github.com/exasol/exasol-driver-go"
+)
+
+func main() {
+	database, err := sql.Open("exasol", "exa:<host>:<port>;user=<username>;password=<password>")
 	...
 }
 ```
@@ -125,7 +128,7 @@ Host-Range-Syntax is supported (e.g. exasol1..exasol3).
 | clientversion    |  string       |           | Tell the server the version of the application. |
 | compression      |  0=off, 1=on  | 0         | Switch data compression on or off.              |
 | encryption       |  0=off, 1=on  | 1         | Switch automatic encryption on or off.          |
-| secure           |  0=off, 1=on  | 1         | TLS/SSL verification. Disable it if you want to use a self-signed or invalid certificate (server side).                         |
+| usetls           |  0=off, 1=on  | 1         | TLS/SSL verification. Disable it if you want to use a self-signed or invalid certificate (server side).                         |
 | fetchsize        | numeric, >0   | 128*1024  | Amount of data in kB which should be obtained by Exasol during a fetch. The JVM can run out of memory if the value is too high. |
 | password         |  string       |           | Exasol password.                                |
 | resultsetmaxrows |  numeric      |           | Set the max amount of rows in the result set.   |
@@ -135,7 +138,6 @@ Host-Range-Syntax is supported (e.g. exasol1..exasol3).
 ## Examples
 
 See [examples](examples)
-
 
 ## Testing / Development
 

--- a/driver.go
+++ b/driver.go
@@ -25,7 +25,7 @@ type config struct {
 	ResultSetMaxRows int
 	Timeout          time.Time
 	Encryption       bool
-	Secure           bool
+	UseTLS           bool
 }
 
 func init() {

--- a/dsn.go
+++ b/dsn.go
@@ -18,7 +18,7 @@ type DSNConfig struct {
 	clientName    string
 	clientVersion string
 	fetchSize     int
-	secure        *bool
+	useTLS        *bool
 }
 
 func NewConfig(user, password string) *DSNConfig {
@@ -42,8 +42,8 @@ func (c *DSNConfig) Autocommit(enabled bool) *DSNConfig {
 	c.autocommit = &enabled
 	return c
 }
-func (c *DSNConfig) Secure(enabled bool) *DSNConfig {
-	c.secure = &enabled
+func (c *DSNConfig) UseTLS(enabled bool) *DSNConfig {
+	c.useTLS = &enabled
 	return c
 }
 func (c *DSNConfig) FetchSize(size int) *DSNConfig {
@@ -79,8 +79,8 @@ func (c *DSNConfig) String() string {
 	if c.encryption != nil {
 		sb.WriteString(fmt.Sprintf("encryption=%d;", boolToInt(*c.encryption)))
 	}
-	if c.secure != nil {
-		sb.WriteString(fmt.Sprintf("secure=%d;", boolToInt(*c.secure)))
+	if c.useTLS != nil {
+		sb.WriteString(fmt.Sprintf("usetls=%d;", boolToInt(*c.useTLS)))
 	}
 	if c.fetchSize != 0 {
 		sb.WriteString(fmt.Sprintf("fetchsize=%d;", c.fetchSize))
@@ -137,7 +137,7 @@ func getDefaultConfig(host string, port int) *config {
 		Autocommit:  true,
 		Encryption:  true,
 		Compression: false,
-		Secure:      true,
+		UseTLS:      true,
 		ClientName:  "Go client",
 		Params:      map[string]string{},
 		FetchSize:   128 * 1024,
@@ -165,8 +165,8 @@ func getConfigWithParameters(host string, port int, parametersString string) (*c
 			config.Autocommit = value == "1"
 		case "encryption":
 			config.Encryption = value == "1"
-		case "secure":
-			config.Secure = value == "1"
+		case "usetls":
+			config.UseTLS = value == "1"
 		case "compression":
 			config.Compression = value == "1"
 		case "clientname":

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -126,6 +126,6 @@ func (suite *DriverTestSuite) TestConfigToDsn() {
 	config.Compression(true)
 	config.Encryption(true)
 	config.Autocommit(true)
-	config.Secure(false)
-	suite.Equal("exa:localhost:8563;user=sys;password=exasol;autocommit=1;compression=1;encryption=1;secure=0", config.String())
+	config.UseTLS(false)
+	suite.Equal("exa:localhost:8563;user=sys;password=exasol;autocommit=1;compression=1;encryption=1;usetls=0", config.String())
 }

--- a/examples/simple.go
+++ b/examples/simple.go
@@ -3,14 +3,13 @@ package main
 import (
 	"database/sql"
 	"fmt"
+	"github.com/exasol/exasol-driver-go"
 	"log"
-
-	_ "github.com/exasol/exasol-driver-go"
 )
 
 func main() {
 	fmt.Printf("Drivers=%#v\n", sql.Drivers())
-	database, err := sql.Open("exasol", "exa:localhost:8563;user=sys;password=<password>")
+	database, err := sql.Open("exasol", exasol.NewConfig("<username>", "<password>").Host("<host>").Port(8563).String())
 	onError(err)
 	defer database.Close()
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -37,7 +37,7 @@ func (suite *IntegrationTestSuite) SetupSuite() {
 }
 
 func (suite *IntegrationTestSuite) TestConnect() {
-	database, _ := sql.Open("exasol", fmt.Sprintf("exa:localhost:%d;user=sys;password=exasol;secure=0", suite.port))
+	database, _ := sql.Open("exasol", fmt.Sprintf("exa:localhost:%d;user=sys;password=exasol;usetls=0", suite.port))
 	rows, _ := database.Query("SELECT 2 FROM DUAL")
 	columns, _ := rows.Columns()
 	suite.Equal("2", columns[0])
@@ -51,17 +51,17 @@ func (suite *IntegrationTestSuite) TestConnectWithWrongPort() {
 }
 
 func (suite *IntegrationTestSuite) TestConnectWithWrongUsername() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("wronguser", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("wronguser", "exasol").UseTLS(false).Port(suite.port).String())
 	suite.EqualError(database.Ping(), "[08004] Connection exception - authentication failed.")
 }
 
 func (suite *IntegrationTestSuite) TestConnectWithWrongPassword() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "wrongpassword").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "wrongpassword").UseTLS(false).Port(suite.port).String())
 	suite.EqualError(database.Ping(), "[08004] Connection exception - authentication failed.")
 }
 
 func (suite *IntegrationTestSuite) TestExecAndQuery() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).String())
 	schemaName := "TEST_SCHEMA_1"
 	_, _ = database.Exec("CREATE SCHEMA " + schemaName)
 	_, _ = database.Exec("CREATE TABLE " + schemaName + ".TEST_TABLE(x INT)")
@@ -71,14 +71,14 @@ func (suite *IntegrationTestSuite) TestExecAndQuery() {
 }
 
 func (suite *IntegrationTestSuite) TestExecuteWithError() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).String())
 	_, err := database.Exec("CREATE SCHEMAA TEST_SCHEMA")
 	suite.Error(err)
 	suite.True(strings.Contains(err.Error(), "syntax error"))
 }
 
 func (suite *IntegrationTestSuite) TestQueryWithError() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).String())
 	schemaName := "TEST_SCHEMA_2"
 	_, _ = database.Exec("CREATE SCHEMA " + schemaName)
 	_, err := database.Query("SELECT x FROM " + schemaName + ".TEST_TABLE")
@@ -87,7 +87,7 @@ func (suite *IntegrationTestSuite) TestQueryWithError() {
 }
 
 func (suite *IntegrationTestSuite) TestPreparedStatement() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).String())
 	schemaName := "TEST_SCHEMA_3"
 	_, _ = database.Exec("CREATE SCHEMA " + schemaName)
 	_, _ = database.Exec("CREATE TABLE " + schemaName + ".TEST_TABLE(x INT)")
@@ -99,7 +99,7 @@ func (suite *IntegrationTestSuite) TestPreparedStatement() {
 }
 
 func (suite *IntegrationTestSuite) TestBeginAndCommit() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Autocommit(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Autocommit(false).Port(suite.port).String())
 	schemaName := "TEST_SCHEMA_4"
 	transaction, _ := database.Begin()
 	_, _ = transaction.Exec("CREATE SCHEMA " + schemaName)
@@ -111,7 +111,7 @@ func (suite *IntegrationTestSuite) TestBeginAndCommit() {
 }
 
 func (suite *IntegrationTestSuite) TestBeginAndRollback() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Autocommit(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Autocommit(false).Port(suite.port).String())
 	schemaName := "TEST_SCHEMA_5"
 	transaction, _ := database.Begin()
 	_, _ = transaction.Exec("CREATE SCHEMA " + schemaName)
@@ -124,14 +124,14 @@ func (suite *IntegrationTestSuite) TestBeginAndRollback() {
 }
 
 func (suite *IntegrationTestSuite) TestPingWithContext() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).String())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	suite.NoError(database.PingContext(ctx))
 	cancel()
 }
 
 func (suite *IntegrationTestSuite) TestExecuteAndQueryWithContext() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).String())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	schemaName := "TEST_SCHEMA_6"
 	_, _ = database.ExecContext(ctx, "CREATE SCHEMA "+schemaName)
@@ -143,7 +143,7 @@ func (suite *IntegrationTestSuite) TestExecuteAndQueryWithContext() {
 }
 
 func (suite *IntegrationTestSuite) TestBeginWithCancelledContext() {
-	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").Secure(false).Port(suite.port).Autocommit(false).String())
+	database, _ := sql.Open("exasol", exasol.NewConfig("sys", "exasol").UseTLS(false).Port(suite.port).Autocommit(false).String())
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	schemaName := "TEST_SCHEMA_7"
 	transaction, _ := database.BeginTx(ctx, nil)

--- a/websocket.go
+++ b/websocket.go
@@ -77,7 +77,7 @@ func (c *connection) connect() error {
 			Host:   uri,
 		}
 		dialer := *websocket.DefaultDialer
-		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: !c.config.Secure}
+		dialer.TLSClientConfig = &tls.Config{InsecureSkipVerify: !c.config.UseTLS}
 
 		var ws *websocket.Conn
 		ws, _, err = dialer.DialContext(c.ctx, u.String(), nil)


### PR DESCRIPTION
As @redcatbear suggested, we have renamed secure to usetls