### PR TITLE
perf(#72): improve memory consumption for large data queries

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -199,8 +199,9 @@ func (suite *IntegrationTestSuite) TestFetch() {
 		data = append(data, fmt.Sprintf("(%d)", i))
 	}
 	_, _ = database.Exec("INSERT INTO " + schemaName + ".TEST_TABLE VALUES " + strings.Join(data, ","))
-	rows, _ := database.Query("SELECT x FROM " + schemaName + ".TEST_TABLE")
+	rows, _ := database.Query("SELECT x FROM " + schemaName + ".TEST_TABLE GROUP BY x ORDER BY x")
 	result := make([]int, 0)
+	counter := 0
 	for rows.Next() {
 		var x int
 		if err := rows.Scan(&x); err != nil {
@@ -208,7 +209,9 @@ func (suite *IntegrationTestSuite) TestFetch() {
 			// Query rows will be closed with defer.
 			log.Fatal(err)
 		}
+		suite.Equal(data[counter], fmt.Sprintf("(%d)", x))
 		result = append(result, x)
+		counter++
 	}
 	suite.Equal(10000, len(result))
 }

--- a/result_set.go
+++ b/result_set.go
@@ -95,7 +95,7 @@ func (results *queryResults) Next(dest []driver.Value) error {
 		results.rowPointer = 0
 		results.fetchedRows = results.fetchedRows + result.NumRows
 
-		// Overwrite old data, user needs to collect the whole date if needed
+		// Overwrite old data, user needs to collect the whole data if needed
 		results.data.Data = result.Data
 
 	}

--- a/result_set.go
+++ b/result_set.go
@@ -6,13 +6,16 @@ import (
 	"database/sql/driver"
 	"io"
 	"reflect"
+	"sync"
 )
 
 type queryResults struct {
-	data        *SQLQueryResponseResultSetData
-	con         *connection
-	fetchedRows int
-	rowPointer  int
+	sync.Mutex      // guards following
+	data            *SQLQueryResponseResultSetData
+	con             *connection
+	fetchedRows     int
+	totalRowPointer int
+	rowPointer      int
 }
 
 func (results *queryResults) ColumnTypeDatabaseTypeName(index int) string {
@@ -74,37 +77,38 @@ func (results *queryResults) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
-	if results.rowPointer >= results.data.NumRows {
+	if results.totalRowPointer >= results.data.NumRows {
 		return io.EOF
 	}
 
-	if results.data.NumRowsInMessage < results.data.NumRows && results.rowPointer == results.fetchedRows {
+	results.Lock()
+	defer results.Unlock()
+
+	if results.data.NumRowsInMessage < results.data.NumRows && results.totalRowPointer == results.fetchedRows {
 		result := &SQLQueryResponseResultSetData{}
 		err := results.con.send(context.Background(), &FetchCommand{
 			Command:         Command{"fetch"},
 			ResultSetHandle: results.data.ResultSetHandle,
-			StartPosition:   results.rowPointer,
+			StartPosition:   results.totalRowPointer,
 			NumBytes:        results.con.config.fetchSize,
 		}, result)
 		if err != nil {
 			return err
 		}
-
+		results.rowPointer = 0
 		results.fetchedRows = results.fetchedRows + result.NumRows
 
-		if results.data.Data == nil {
-			results.data.Data = result.Data
-		} else {
-			for i, d := range result.Data {
-				results.data.Data[i] = append(results.data.Data[i], d...)
-			}
-		}
+		// Overwrite old data, user needs to collect the whole date if needed
+		results.data.Data = result.Data
 
 	}
 
 	for i := range dest {
 		dest[i] = results.data.Data[i][results.rowPointer]
 	}
+
 	results.rowPointer = results.rowPointer + 1
+	results.totalRowPointer = results.totalRowPointer + 1
+
 	return nil
 }

--- a/result_set.go
+++ b/result_set.go
@@ -81,9 +81,6 @@ func (results *queryResults) Next(dest []driver.Value) error {
 		return io.EOF
 	}
 
-	results.Lock()
-	defer results.Unlock()
-
 	if results.data.NumRowsInMessage < results.data.NumRows && results.totalRowPointer == results.fetchedRows {
 		result := &SQLQueryResponseResultSetData{}
 		err := results.con.send(context.Background(), &FetchCommand{

--- a/result_set_test.go
+++ b/result_set_test.go
@@ -154,6 +154,6 @@ func (suite *ResultSetTestSuite) TestNextWithoutRows() {
 
 func (suite *ResultSetTestSuite) TestNextPointerDoesNotMatch() {
 	data := SQLQueryResponseResultSetData{NumRows: 1}
-	queryResults := queryResults{data: &data, rowPointer: 2}
+	queryResults := queryResults{data: &data, totalRowPointer: 2}
 	suite.EqualError(queryResults.Next(nil), "EOF")
 }


### PR DESCRIPTION
We saved all data im memory during queries with a lot of data.
To avoid this issue we only save now the current slice of data in memory. 
Older date is not needed anymore and can be safely discarded as the user already read the data.  
We now only save the current slice of data to avoid a lot of memory use. 