### PR TITLE
#95: Add unit tests with mocked websocket connection

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,10 @@ jobs:
     strategy:
       matrix:
         go: ["1.20", "1.21"]
-        db: ["7.1.22", "8.20.0"]
+        db: ["7.1.22", "8.22.0"]
     env:
-      DEFAULT_GO: "1.20"
-      DEFAULT_DB: "7.1.22"
+      DEFAULT_GO: "1.21"
+      DEFAULT_DB: "8.22.0"
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-go-${{ matrix.go }}-db-${{ matrix.db }}
       cancel-in-progress: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ["1.19", "1.20"]
+        go: ["1.20", "1.21"]
         db: ["7.1.22", "8.20.0"]
     env:
       DEFAULT_GO: "1.20"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,11 +52,15 @@ jobs:
         run: |
           go clean
           go build
+          go build ./...
 
-      - name: test
+      - name: Go test -short
+        run: go test -v -count 1 -short ./...
+
+      - name: Go test with Exasol version ${{ matrix.db }}
         env:
           DB_VERSION: ${{ matrix.db }}
-        run: go test -v -coverprofile=coverage.out ./...
+        run: go test -v -count 1 -coverprofile=coverage.out ./...
 
       - name: SonarCloud Scan
         if: matrix.go == env.DEFAULT_GO && matrix.db == env.DEFAULT_DB && github.repository_owner == 'exasol'

--- a/.github/workflows/project-keeper-verify.yml
+++ b/.github/workflows/project-keeper-verify.yml
@@ -25,9 +25,9 @@ jobs:
           java-version: 11
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: "1.20"
 
 
 

--- a/.github/workflows/project-keeper.sh
+++ b/.github/workflows/project-keeper.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 readonly pk_mode="${1-verify}";
-readonly version="2.9.9"
+readonly version="2.9.11"
 
 readonly pk_jar="$HOME/.m2/repository/com/exasol/project-keeper-cli/$version/project-keeper-cli-$version.jar"
 

--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -1,4 +1,4 @@
 sources:
   - type: golang
     path: go.mod
-version: 1.0.1
+version: 1.0.2

--- a/dependencies.md
+++ b/dependencies.md
@@ -3,25 +3,25 @@
 
 ## Compile Dependencies
 
-| Dependency                           | License           |
-| ------------------------------------ | ----------------- |
-| github.com/exasol/error-reporting-go | [MIT][0]          |
-| github.com/gorilla/websocket         | [BSD-2-Clause][1] |
+| Dependency                                                       | License           |
+| ---------------------------------------------------------------- | ----------------- |
+| github.com/exasol/error-reporting-go                             | [MIT][0]          |
+| github.com/exasol/exasol-test-setup-abstraction-server/go-client | [MIT][1]          |
+| github.com/gorilla/websocket                                     | [BSD-2-Clause][2] |
+| github.com/stretchr/testify                                      | [MIT][3]          |
+| gopkg.in/yaml.v3                                                 | [MIT][4]          |
 
 ## Test Dependencies
 
-| Dependency                                                       | License           |
-| ---------------------------------------------------------------- | ----------------- |
-| github.com/exasol/exasol-test-setup-abstraction-server/go-client | [MIT][2]          |
-| github.com/stretchr/testify                                      | [MIT][3]          |
-| go.uber.org/goleak                                               | [MIT][4]          |
-| golang.org/x/sync                                                | [BSD-3-Clause][5] |
-| gopkg.in/yaml.v3                                                 | [MIT][6]          |
+| Dependency         | License           |
+| ------------------ | ----------------- |
+| go.uber.org/goleak | [MIT][5]          |
+| golang.org/x/sync  | [BSD-3-Clause][6] |
 
 [0]: https://github.com/exasol/error-reporting-go/blob/v0.2.0/LICENSE
-[1]: https://github.com/gorilla/websocket/blob/v1.5.0/LICENSE
-[2]: https://github.com/exasol/exasol-test-setup-abstraction-server/blob/HEAD/go-client/LICENSE
-[3]: https://github.com/stretchr/testify/blob/HEAD/LICENSE
-[4]: https://github.com/uber-go/goleak/blob/HEAD/LICENSE
-[5]: https://cs.opensource.google/go/x/sync/+/v0.3.0:LICENSE
-[6]: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
+[1]: https://github.com/exasol/exasol-test-setup-abstraction-server/blob/go-client/v0.3.3/go-client/LICENSE
+[2]: https://github.com/gorilla/websocket/blob/v1.5.0/LICENSE
+[3]: https://github.com/stretchr/testify/blob/v1.8.4/LICENSE
+[4]: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
+[5]: https://github.com/uber-go/goleak/blob/HEAD/LICENSE
+[6]: https://cs.opensource.google/go/x/sync/+/v0.3.0:LICENSE

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [1.0.2](changes_1.0.2.md)
 * [1.0.1](changes_1.0.1.md)
 * [1.0.0](changes_1.0.0.md)
 * [0.4.7](changes_0.4.7.md)

--- a/doc/changes/changes_1.0.1.md
+++ b/doc/changes/changes_1.0.1.md
@@ -13,14 +13,3 @@ The release also adds integration tests with Exasol v8. Exasol version 7.0 is de
 * #92: Added tests with Exasol v8
 * #89: Added query timeout to DSN
 
-## Dependency Updates
-
-### Compile Dependency Updates
-
-* Updated `github.com/exasol/error-reporting-go:v0.1.1` to `v0.2.0`
-
-### Test Dependency Updates
-
-* Updated `golang.org/x/sync:v0.1.0` to `v0.3.0`
-* Updated `github.com/stretchr/testify:v1.8.2` to `v1.8.4`
-* Updated `github.com/exasol/exasol-test-setup-abstraction-server/go-client:v0.3.2` to `v0.3.3`

--- a/doc/changes/changes_1.0.1.md
+++ b/doc/changes/changes_1.0.1.md
@@ -13,3 +13,14 @@ The release also adds integration tests with Exasol v8. Exasol version 7.0 is de
 * #92: Added tests with Exasol v8
 * #89: Added query timeout to DSN
 
+## Dependency Updates
+
+### Compile Dependency Updates
+
+* Updated `github.com/exasol/error-reporting-go:v0.1.1` to `v0.2.0`
+
+### Test Dependency Updates
+
+* Updated `golang.org/x/sync:v0.1.0` to `v0.3.0`
+* Updated `github.com/stretchr/testify:v1.8.2` to `v1.8.4`
+* Updated `github.com/exasol/exasol-test-setup-abstraction-server/go-client:v0.3.2` to `v0.3.3`

--- a/doc/changes/changes_1.0.2.md
+++ b/doc/changes/changes_1.0.2.md
@@ -8,3 +8,8 @@ Code name:
 
 * ISSUE_NUMBER: description
 
+## Dependency Updates
+
+### Compile Dependency Updates
+
+* Updated `golang:1.19` to `1.20`

--- a/doc/changes/changes_1.0.2.md
+++ b/doc/changes/changes_1.0.2.md
@@ -1,4 +1,4 @@
-# Exasol Driver go 1.0.2, released 2023-08-31
+# Exasol Driver go 1.0.2, released 2023-09-04
 
 Code name: Improve Test Coverage
 

--- a/doc/changes/changes_1.0.2.md
+++ b/doc/changes/changes_1.0.2.md
@@ -1,8 +1,12 @@
-# Exasol Driver go 1.0.2, released 2023-??-??
+# Exasol Driver go 1.0.2, released 2023-08-31
 
-Code name:
+Code name: Improve Test Coverage
 
 ## Summary
+
+This release refactors the websocket communication code to allow unit testing and improve test coverage.
+
+The release also upgrades the required Go version from 1.19 to 1.20.
 
 ## Refactoring
 

--- a/doc/changes/changes_1.0.2.md
+++ b/doc/changes/changes_1.0.2.md
@@ -1,0 +1,10 @@
+# Exasol Driver go 1.0.2, released 2023-??-??
+
+Code name:
+
+## Summary
+
+## Features
+
+* ISSUE_NUMBER: description
+

--- a/doc/changes/changes_1.0.2.md
+++ b/doc/changes/changes_1.0.2.md
@@ -4,9 +4,9 @@ Code name:
 
 ## Summary
 
-## Features
+## Refactoring
 
-* ISSUE_NUMBER: description
+* #95: Improved unit test coverage
 
 ## Dependency Updates
 

--- a/driver_test.go
+++ b/driver_test.go
@@ -16,28 +16,30 @@ func TestDriverSuite(t *testing.T) {
 
 func (suite *DriverTestSuite) TestOpenConnector() {
 	exasolDriver := ExasolDriver{}
-	_, err := exasolDriver.OpenConnector("exa:localhost:1234")
+	conn, err := exasolDriver.OpenConnector("exa:localhost:1234")
 	suite.NoError(err)
+	suite.NotNil(conn)
 }
 
 func (suite *DriverTestSuite) TestOpenConnectorBadDsn() {
 	exasolDriver := ExasolDriver{}
-	_, err := exasolDriver.OpenConnector("")
-	suite.Error(err)
+	conn, err := exasolDriver.OpenConnector("")
+	suite.EqualError(err, "E-EGOD-21: invalid connection string, must start with 'exa:': ''")
+	suite.Nil(conn)
 }
 
 func (suite *DriverTestSuite) TestOpen() {
 	exasolDriver := ExasolDriver{}
-	_, err := exasolDriver.Open("exa:localhost:1234")
-	suite.Error(err)
+	conn, err := exasolDriver.Open("exa:localhost:1234")
 	suite.ErrorContains(err, "connection refused")
+	suite.Nil(conn)
 }
 
 func (suite *DriverTestSuite) TestOpenBadDsn() {
 	exasolDriver := ExasolDriver{}
-	_, err := exasolDriver.Open("")
-	suite.Error(err)
-	suite.ErrorContains(err, "invalid connection string")
+	conn, err := exasolDriver.Open("")
+	suite.EqualError(err, "E-EGOD-21: invalid connection string, must start with 'exa:': ''")
+	suite.Nil(conn)
 }
 
 func (suite *DriverTestSuite) TestConfigToDsnWithBooleanValuesTrue() {

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	golang.org/x/net v0.14.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,6 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	github.com/stretchr/objx v0.5.0 // indirect
+	github.com/stretchr/objx v0.5.1 // indirect
 	golang.org/x/net v0.14.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/exasol/exasol-driver-go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/exasol/error-reporting-go v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -17,5 +17,5 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	golang.org/x/net v0.13.0 // indirect
+	golang.org/x/net v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -20,11 +20,13 @@ github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDN
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
-github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.1 h1:4VhoImhV/Bm0ToFkXFi8hXNXwpDRZ/ynw3amt82mzq0=
+github.com/stretchr/objx v0.5.1/go.mod h1:/iHQpkQwBD6DLUmQ4pE+s1TXdob1mORJ4/UFdrifcy0=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=

--- a/go.sum
+++ b/go.sum
@@ -24,11 +24,11 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
-golang.org/x/net v0.13.0 h1:Nvo8UFsZ8X3BhAC9699Z1j7XQ3rsZnUUm7jfBEk1ueY=
-golang.org/x/net v0.13.0/go.mod h1:zEVYFnQC7m/vmpQFELhcD1EWkZlX69l4oqgmer6hfKA=
+golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
+golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/text v0.11.0 h1:LAntKIrcmeSKERyiOh0XMV39LXS8IE9UL2yP7+f5ij4=
+golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -19,7 +19,12 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const DriverVersion = "v1.0.1"
+const DriverVersion = "v1.0.2"

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -169,6 +169,7 @@ func (c *Connection) executePreparedStatement(ctx context.Context, s *types.Crea
 		return nil, err
 	}
 	if result.NumResults == 0 {
+		logger.ErrorLogger.Printf("Got empty result of type %t: %v", result, result)
 		return nil, errors.ErrMalformedData
 	}
 	return result, c.closePreparedStatement(ctx, s)
@@ -271,6 +272,7 @@ func (c *Connection) SimpleExec(ctx context.Context, query string) (*types.SqlQu
 		return nil, err
 	}
 	if result.NumResults == 0 {
+		logger.ErrorLogger.Printf("Got empty result of type %t: %v", result, result)
 		return nil, errors.ErrMalformedData
 	}
 	return result, err

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -16,17 +16,16 @@ import (
 	"github.com/exasol/exasol-driver-go/internal/config"
 	"github.com/exasol/exasol-driver-go/internal/utils"
 	"github.com/exasol/exasol-driver-go/internal/version"
+	"github.com/exasol/exasol-driver-go/pkg/connection/wsconn"
 	"github.com/exasol/exasol-driver-go/pkg/errors"
 	"github.com/exasol/exasol-driver-go/pkg/logger"
 	"github.com/exasol/exasol-driver-go/pkg/types"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/gorilla/websocket"
 )
 
 type Connection struct {
 	Config    *config.Config
-	websocket *websocket.Conn
+	websocket wsconn.WebsocketConnection
 	Ctx       context.Context
 	IsClosed  bool
 }

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"math/big"
 	"os/user"
 	"runtime"
@@ -276,6 +277,7 @@ func (c *Connection) SimpleExec(ctx context.Context, query string) (*types.SqlQu
 }
 
 func (c *Connection) close(ctx context.Context) error {
+	log.Printf("Closing connection")
 	c.IsClosed = true
 	err := c.Send(ctx, &types.Command{Command: "disconnect"}, nil)
 	c.websocket.Close()

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -40,13 +40,6 @@ func (suite *ConnectionTestSuite) TestQueryContextNamedParametersNotSupported() 
 	suite.Nil(rows)
 }
 
-func (suite *ConnectionTestSuite) TestQueryContextNotConnected() {
-	suite.websocketMock = nil
-	rows, err := suite.createOpenConnection().QueryContext(context.Background(), "query", []driver.NamedValue{{Ordinal: 1, Value: "value"}})
-	suite.EqualError(err, `E-EGOD-29: could not send request '{"command":"createPreparedStatement","sqlText":"query","attributes":{}}': not connected to server`)
-	suite.Nil(rows)
-}
-
 func (suite *ConnectionTestSuite) TestQueryContext() {
 	suite.websocketMock.SimulateOKResponse(
 		types.SqlCommand{

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -1,0 +1,82 @@
+package connection
+
+import (
+	"context"
+	"database/sql/driver"
+	"testing"
+
+	"github.com/exasol/exasol-driver-go/internal/config"
+	"github.com/exasol/exasol-driver-go/pkg/connection/wsconn"
+	"github.com/exasol/exasol-driver-go/pkg/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type ConnectionTestSuite struct {
+	suite.Suite
+	websocketMock *wsconn.WebsocketConnectionMock
+}
+
+func TestConnectionSuite(t *testing.T) {
+	suite.Run(t, new(ConnectionTestSuite))
+}
+
+func (suite *ConnectionTestSuite) SetupTest() {
+	suite.websocketMock = wsconn.CreateWebsocketConnectionMock()
+}
+
+func (suite *ConnectionTestSuite) TestConnectFails() {
+	conn := &Connection{
+		Config:   &config.Config{Host: "invalid", Port: 12345},
+		Ctx:      context.Background(),
+		IsClosed: true,
+	}
+	err := conn.Connect()
+	suite.ErrorContains(err, `failed to connect to URL "ws://invalid:12345": dial tcp: lookup invalid: no such host`)
+}
+
+func (suite *ConnectionTestSuite) TestQueryContextNamedParametersNotSupported() {
+	rows, err := suite.createOpenConnection().QueryContext(context.Background(), "query", []driver.NamedValue{{Name: "arg", Ordinal: 1, Value: "value"}})
+	suite.EqualError(err, "E-EGOD-7: named parameters not supported")
+	suite.Nil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryContextNotConnected() {
+	suite.websocketMock = nil
+	rows, err := suite.createOpenConnection().QueryContext(context.Background(), "query", []driver.NamedValue{{Ordinal: 1, Value: "value"}})
+	suite.EqualError(err, `E-EGOD-29: could not send request '{"command":"createPreparedStatement","sqlText":"query","attributes":{}}': not connected to server`)
+	suite.Nil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryContext() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+
+	suite.websocketMock.SimulateSQLQueriesResponse(
+		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
+			StatementHandle: 0, NumColumns: 1, NumRows: 1,
+			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
+			Data:    [][]interface{}{{"value"}},
+		},
+		[]types.SqlQueryResponseResultSet{{ResultType: "resultType", ResultSet: types.SqlQueryResponseResultSetData{}}})
+
+	suite.websocketMock.SimulateOKResponse(types.ClosePreparedStatementCommand{Command: types.Command{Command: "closePreparedStatement"}, StatementHandle: 0, Attributes: types.Attributes{}}, nil)
+	rows, err := suite.createOpenConnection().QueryContext(context.Background(), "query", []driver.NamedValue{{Ordinal: 1, Value: "value"}})
+	suite.NoError(err)
+	suite.Equal([]string{}, rows.Columns())
+}
+
+func (suite *ConnectionTestSuite) createOpenConnection() *Connection {
+	conn := &Connection{
+		Config:    &config.Config{Host: "invalid", Port: 12345},
+		Ctx:       context.Background(),
+		IsClosed:  false,
+		websocket: suite.websocketMock,
+	}
+	return conn
+}

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -147,7 +147,7 @@ func (suite *ConnectionTestSuite) TestPrepareContextFailsClosed() {
 	conn := suite.createOpenConnection()
 	conn.IsClosed = true
 	stmt, err := conn.PrepareContext(context.Background(), "query")
-	suite.EqualError(err, "driver: bad connection")
+	suite.EqualError(err, driver.ErrBadConn.Error())
 	suite.Nil(stmt)
 }
 
@@ -226,7 +226,7 @@ func (suite *ConnectionTestSuite) TestBeginFailsWithConnectionClosed() {
 	conn := suite.createOpenConnection()
 	conn.IsClosed = true
 	tx, err := conn.Begin()
-	suite.EqualError(err, "driver: bad connection")
+	suite.EqualError(err, driver.ErrBadConn.Error())
 	suite.Nil(tx)
 }
 
@@ -242,7 +242,7 @@ func (suite *ConnectionTestSuite) TestQueryFailsConnectionClosed() {
 	conn := suite.createOpenConnection()
 	conn.IsClosed = true
 	rows, err := conn.query(context.Background(), "query", nil)
-	suite.EqualError(err, "driver: bad connection")
+	suite.EqualError(err, driver.ErrBadConn.Error())
 	suite.Nil(rows)
 }
 

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -31,7 +31,7 @@ func (suite *ConnectionTestSuite) TestConnectFails() {
 		IsClosed: true,
 	}
 	err := conn.Connect()
-	suite.ErrorContains(err, `failed to connect to URL "ws://invalid:12345": dial tcp: lookup invalid: no such host`)
+	suite.ErrorContains(err, `failed to connect to URL "ws://invalid:12345": dial tcp`)
 }
 
 func (suite *ConnectionTestSuite) TestQueryContextNamedParametersNotSupported() {

--- a/pkg/connection/connection_test.go
+++ b/pkg/connection/connection_test.go
@@ -3,6 +3,7 @@ package connection
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 	"testing"
 
 	"github.com/exasol/exasol-driver-go/internal/config"
@@ -49,19 +50,277 @@ func (suite *ConnectionTestSuite) TestQueryContext() {
 		},
 		types.CreatePreparedStatementResponse{
 			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
-
 	suite.websocketMock.SimulateSQLQueriesResponse(
 		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
 			StatementHandle: 0, NumColumns: 1, NumRows: 1,
 			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
 			Data:    [][]interface{}{{"value"}},
 		},
-		[]types.SqlQueryResponseResultSet{{ResultType: "resultType", ResultSet: types.SqlQueryResponseResultSetData{}}})
-
+		types.SqlQueryResponseResultSet{ResultType: "resultType", ResultSet: types.SqlQueryResponseResultSetData{}})
 	suite.websocketMock.SimulateOKResponse(types.ClosePreparedStatementCommand{Command: types.Command{Command: "closePreparedStatement"}, StatementHandle: 0, Attributes: types.Attributes{}}, nil)
+
 	rows, err := suite.createOpenConnection().QueryContext(context.Background(), "query", []driver.NamedValue{{Ordinal: 1, Value: "value"}})
 	suite.NoError(err)
 	suite.Equal([]string{}, rows.Columns())
+}
+
+func (suite *ConnectionTestSuite) TestQuery() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	suite.websocketMock.SimulateSQLQueriesResponse(
+		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
+			StatementHandle: 0, NumColumns: 1, NumRows: 1,
+			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
+			Data:    [][]interface{}{{"value"}},
+		},
+		types.SqlQueryResponseResultSet{ResultType: "resultType", ResultSet: types.SqlQueryResponseResultSetData{}})
+	suite.websocketMock.SimulateOKResponse(types.ClosePreparedStatementCommand{Command: types.Command{Command: "closePreparedStatement"}, StatementHandle: 0, Attributes: types.Attributes{}}, nil)
+
+	rows, err := suite.createOpenConnection().Query("query", []driver.Value{"value"})
+	suite.NoError(err)
+	suite.Equal([]string{}, rows.Columns())
+}
+
+func (suite *ConnectionTestSuite) TestExecContextNamedParametersNotSupported() {
+	rows, err := suite.createOpenConnection().ExecContext(context.Background(), "query", []driver.NamedValue{{Name: "arg", Ordinal: 1, Value: "value"}})
+	suite.EqualError(err, "E-EGOD-7: named parameters not supported")
+	suite.Nil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestExecContext() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	suite.websocketMock.SimulateSQLQueriesResponse(
+		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
+			StatementHandle: 0, NumColumns: 1, NumRows: 1,
+			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
+			Data:    [][]interface{}{{"value"}},
+		},
+		types.SqlQueryResponseRowCount{ResultType: "resultType", RowCount: 42})
+	suite.websocketMock.SimulateOKResponse(types.ClosePreparedStatementCommand{Command: types.Command{Command: "closePreparedStatement"}, StatementHandle: 0, Attributes: types.Attributes{}}, nil)
+
+	rows, err := suite.createOpenConnection().ExecContext(context.Background(), "query", []driver.NamedValue{{Ordinal: 1, Value: "value"}})
+	suite.NoError(err)
+	rowsAffected, err := rows.RowsAffected()
+	suite.NoError(err)
+	suite.Equal(int64(42), rowsAffected)
+}
+
+func (suite *ConnectionTestSuite) TestExec() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	suite.websocketMock.SimulateSQLQueriesResponse(
+		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
+			StatementHandle: 0, NumColumns: 1, NumRows: 1,
+			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
+			Data:    [][]interface{}{{"value"}},
+		},
+		types.SqlQueryResponseRowCount{ResultType: "resultType", RowCount: 42})
+	suite.websocketMock.SimulateOKResponse(types.ClosePreparedStatementCommand{Command: types.Command{Command: "closePreparedStatement"}, StatementHandle: 0, Attributes: types.Attributes{}}, nil)
+
+	rows, err := suite.createOpenConnection().Exec("query", []driver.Value{"value"})
+	suite.NoError(err)
+	rowsAffected, err := rows.RowsAffected()
+	suite.NoError(err)
+	suite.Equal(int64(42), rowsAffected)
+}
+
+func (suite *ConnectionTestSuite) TestPrepareContextFailsClosed() {
+	conn := suite.createOpenConnection()
+	conn.IsClosed = true
+	stmt, err := conn.PrepareContext(context.Background(), "query")
+	suite.EqualError(err, "driver: bad connection")
+	suite.Nil(stmt)
+}
+
+func (suite *ConnectionTestSuite) TestPrepareContextPreparedStatementFails() {
+	suite.websocketMock.SimulateErrorResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.Exception{Text: "mock error", SQLCode: "mock sql code"})
+	stmt, err := suite.createOpenConnection().PrepareContext(context.Background(), "query")
+	suite.ErrorContains(err, "E-EGOD-11: execution failed with SQL error code 'mock sql code' and message 'mock error'")
+	suite.Nil(stmt)
+}
+
+func (suite *ConnectionTestSuite) TestPrepareContextSuccess() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	stmt, err := suite.createOpenConnection().PrepareContext(context.Background(), "query")
+	suite.NoError(err)
+	suite.NotNil(stmt)
+}
+
+func (suite *ConnectionTestSuite) TestPrepareSuccess() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	stmt, err := suite.createOpenConnection().Prepare("query")
+	suite.NoError(err)
+	suite.NotNil(stmt)
+}
+
+func (suite *ConnectionTestSuite) TestCloseSuccess() {
+	suite.websocketMock.SimulateOKResponse(types.Command{Command: "disconnect"}, nil)
+	suite.websocketMock.OnClose(nil)
+	conn := suite.createOpenConnection()
+	suite.False(conn.IsClosed)
+	err := conn.Close()
+	suite.NoError(err)
+	suite.True(conn.IsClosed)
+}
+
+func (suite *ConnectionTestSuite) TestCloseDisconnectFails() {
+	suite.websocketMock.SimulateErrorResponse(types.Command{Command: "disconnect"}, types.Exception{Text: "mock error", SQLCode: "mock sql code"})
+	suite.websocketMock.OnClose(nil)
+	err := suite.createOpenConnection().Close()
+	suite.EqualError(err, "E-EGOD-11: execution failed with SQL error code 'mock sql code' and message 'mock error'")
+}
+
+func (suite *ConnectionTestSuite) TestCloseWebsocketCloseFails() {
+	suite.websocketMock.SimulateOKResponse(types.Command{Command: "disconnect"}, nil)
+	suite.websocketMock.OnClose(fmt.Errorf("mock error"))
+	err := suite.createOpenConnection().Close()
+	suite.EqualError(err, "failed to close websocket: mock error")
+}
+
+func (suite *ConnectionTestSuite) TestBeginSuccess() {
+	tx, err := suite.createOpenConnection().Begin()
+	suite.NoError(err)
+	suite.NotNil(tx)
+}
+
+func (suite *ConnectionTestSuite) TestBeginFailsWithConnectionClosed() {
+	conn := suite.createOpenConnection()
+	conn.IsClosed = true
+	tx, err := conn.Begin()
+	suite.EqualError(err, "driver: bad connection")
+	suite.Nil(tx)
+}
+
+func (suite *ConnectionTestSuite) TestBeginFailsWithAutocommitEnabled() {
+	conn := suite.createOpenConnection()
+	conn.Config.Autocommit = true
+	tx, err := conn.Begin()
+	suite.EqualError(err, "E-EGOD-4: begin not working when autocommit is enabled")
+	suite.Nil(tx)
+}
+
+func (suite *ConnectionTestSuite) TestQueryFailsConnectionClosed() {
+	conn := suite.createOpenConnection()
+	conn.IsClosed = true
+	rows, err := conn.query(context.Background(), "query", nil)
+	suite.EqualError(err, "driver: bad connection")
+	suite.Nil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryNoArgs() {
+	suite.websocketMock.SimulateSQLQueriesResponse(
+		types.SqlCommand{Command: types.Command{Command: "execute"}, SQLText: "query", Attributes: types.Attributes{}},
+		types.SqlQueryResponseResultSet{ResultType: "resultType", ResultSet: types.SqlQueryResponseResultSetData{}})
+	rows, err := suite.createOpenConnection().query(context.Background(), "query", []driver.Value{})
+	suite.NoError(err)
+	suite.NotNil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryNoArgsFails() {
+	suite.websocketMock.SimulateErrorResponse(
+		types.SqlCommand{Command: types.Command{Command: "execute"}, SQLText: "query", Attributes: types.Attributes{}},
+		types.Exception{Text: "mock error", SQLCode: "mock sql code"})
+	rows, err := suite.createOpenConnection().query(context.Background(), "query", []driver.Value{})
+	suite.EqualError(err, "E-EGOD-11: execution failed with SQL error code 'mock sql code' and message 'mock error'")
+	suite.Nil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryWithArgs() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	suite.websocketMock.SimulateSQLQueriesResponse(
+		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
+			StatementHandle: 0, NumColumns: 1, NumRows: 1,
+			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
+			Data:    [][]interface{}{{"value"}},
+		},
+		types.SqlQueryResponseResultSet{ResultType: "resultType", ResultSet: types.SqlQueryResponseResultSetData{}})
+	suite.websocketMock.SimulateOKResponse(types.ClosePreparedStatementCommand{Command: types.Command{Command: "closePreparedStatement"}, StatementHandle: 0, Attributes: types.Attributes{}}, nil)
+
+	rows, err := suite.createOpenConnection().query(context.Background(), "query", []driver.Value{"value"})
+	suite.NoError(err)
+	suite.NotNil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryWithArgsFailsInPrepare() {
+	suite.websocketMock.SimulateErrorResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.Exception{Text: "mock error", SQLCode: "sql mock"})
+
+	rows, err := suite.createOpenConnection().query(context.Background(), "query", []driver.Value{"value"})
+	suite.EqualError(err, "E-EGOD-11: execution failed with SQL error code 'sql mock' and message 'mock error'")
+	suite.Nil(rows)
+}
+
+func (suite *ConnectionTestSuite) TestQueryWithArgsFailsInExecute() {
+	suite.websocketMock.SimulateOKResponse(
+		types.SqlCommand{
+			Command:    types.Command{Command: "createPreparedStatement"},
+			SQLText:    "query",
+			Attributes: types.Attributes{},
+		},
+		types.CreatePreparedStatementResponse{
+			ParameterData: types.ParameterData{Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}}}})
+	suite.websocketMock.SimulateErrorResponse(
+		types.ExecutePreparedStatementCommand{Command: types.Command{Command: "executePreparedStatement"},
+			StatementHandle: 0, NumColumns: 1, NumRows: 1,
+			Columns: []types.SqlQueryColumn{{Name: "col", DataType: types.SqlQueryColumnType{Type: "type"}}},
+			Data:    [][]interface{}{{"value"}},
+		},
+		types.Exception{Text: "mock error", SQLCode: "sql mock"})
+
+	rows, err := suite.createOpenConnection().query(context.Background(), "query", []driver.Value{"value"})
+	suite.EqualError(err, "E-EGOD-11: execution failed with SQL error code 'sql mock' and message 'mock error'")
+	suite.Nil(rows)
 }
 
 func (suite *ConnectionTestSuite) createOpenConnection() *Connection {

--- a/pkg/connection/result_set_test.go
+++ b/pkg/connection/result_set_test.go
@@ -56,9 +56,9 @@ func (suite *ResultSetTestSuite) TestColumnTypePrecisionScaleWithoutPrecision() 
 }
 
 func (suite *ResultSetTestSuite) TestColumnTypePrecisionScaleWithoutScale() {
-	expectedScale := int64(3)
+	expectedPrecision := int64(3)
 	data := types.SqlQueryResponseResultSetData{Columns: []types.SqlQueryColumn{
-		{DataType: types.SqlQueryColumnType{Scale: &expectedScale}},
+		{DataType: types.SqlQueryColumnType{Precision: &expectedPrecision}},
 	}}
 	queryResults := QueryResults{data: &data}
 	precision, scale, ok := queryResults.ColumnTypePrecisionScale(0)

--- a/pkg/connection/statement.go
+++ b/pkg/connection/statement.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/exasol/exasol-driver-go/internal/utils"
 	"github.com/exasol/exasol-driver-go/pkg/errors"
+	"github.com/exasol/exasol-driver-go/pkg/logger"
 	"github.com/exasol/exasol-driver-go/pkg/types"
 )
 
@@ -105,6 +106,7 @@ func (s *Statement) executePreparedStatement(ctx context.Context, args []driver.
 		return nil, err
 	}
 	if result.NumResults == 0 {
+		logger.ErrorLogger.Printf("Got empty result of type %t: %v", result, result)
 		return nil, errors.ErrMalformedData
 	}
 	return result, err

--- a/pkg/connection/transaction_test.go
+++ b/pkg/connection/transaction_test.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"database/sql/driver"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -27,11 +28,11 @@ func (suite *TransactionTestSuite) TestRollbackWithEmptyConnection() {
 func (suite *TransactionTestSuite) TestCommitWithClosedConnection() {
 	connection := Connection{IsClosed: true}
 	transaction := Transaction{connection: &connection}
-	suite.EqualError(transaction.Commit(), "driver: bad connection")
+	suite.EqualError(transaction.Commit(), driver.ErrBadConn.Error())
 }
 
 func (suite *TransactionTestSuite) TestRollbackWithClosedConnection() {
 	connection := Connection{IsClosed: true}
 	transaction := Transaction{connection: &connection}
-	suite.EqualError(transaction.Rollback(), "driver: bad connection")
+	suite.EqualError(transaction.Rollback(), driver.ErrBadConn.Error())
 }

--- a/pkg/connection/util.go
+++ b/pkg/connection/util.go
@@ -14,7 +14,7 @@ func ToRow(result *types.SqlQueriesResponse, con *Connection) (driver.Rows, erro
 		return nil, err
 	}
 
-	return &QueryResults{data: &resultSet.ResultSet, con: con}, err
+	return &QueryResults{data: &resultSet.ResultSet, con: con}, nil
 }
 
 func ToResult(result *types.SqlQueriesResponse) (driver.Result, error) {
@@ -24,7 +24,5 @@ func ToResult(result *types.SqlQueriesResponse) (driver.Result, error) {
 		return nil, err
 	}
 
-	return &RowCount{
-		affectedRows: int64(rowCountResult.RowCount),
-	}, err
+	return &RowCount{affectedRows: int64(rowCountResult.RowCount)}, nil
 }

--- a/pkg/connection/websocket.go
+++ b/pkg/connection/websocket.go
@@ -141,7 +141,7 @@ func (c *Connection) callback() func(response interface{}) error {
 			if result.Exception != nil {
 				return errors.NewSqlErr(result.Exception.SQLCode, result.Exception.Text)
 			} else {
-				return fmt.Errorf("expected exception in response %v", result)
+				return fmt.Errorf("result status is not 'ok': %q, expected exception in response %v", result.Status, result)
 			}
 		}
 

--- a/pkg/connection/websocket.go
+++ b/pkg/connection/websocket.go
@@ -133,12 +133,16 @@ func (c *Connection) callback() func(response interface{}) error {
 
 		err = json.NewDecoder(reader).Decode(result)
 		if err != nil {
-			logger.ErrorLogger.Print(errors.NewJsonDecodingError(err))
+			logger.ErrorLogger.Print(errors.NewJsonDecodingError(err, message))
 			return driver.ErrBadConn
 		}
 
 		if result.Status != "ok" {
-			return errors.NewSqlErr(result.Exception.SQLCode, result.Exception.Text)
+			if result.Exception != nil {
+				return errors.NewSqlErr(result.Exception.SQLCode, result.Exception.Text)
+			} else {
+				return fmt.Errorf("expected exception in response %v", result)
+			}
 		}
 
 		if response == nil {

--- a/pkg/connection/websocket.go
+++ b/pkg/connection/websocket.go
@@ -103,7 +103,6 @@ func (c *Connection) asyncSend(request interface{}) (func(interface{}) error, er
 	err = c.websocket.WriteMessage(messageType, message)
 	if err != nil {
 		logger.ErrorLogger.Print(errors.NewRequestSendingError(err))
-
 		return nil, driver.ErrBadConn
 	}
 
@@ -149,6 +148,10 @@ func (c *Connection) callback() func(response interface{}) error {
 			return nil
 		}
 
-		return json.Unmarshal(result.ResponseData, response)
+		err = json.Unmarshal(result.ResponseData, response)
+		if err != nil {
+			return fmt.Errorf("failed to parse response data %q: %w", result.ResponseData, err)
+		}
+		return nil
 	}
 }

--- a/pkg/connection/websocket_test.go
+++ b/pkg/connection/websocket_test.go
@@ -1,0 +1,146 @@
+package connection
+
+import (
+	"context"
+	"database/sql/driver"
+	"fmt"
+	"testing"
+
+	"github.com/exasol/exasol-driver-go/internal/config"
+	"github.com/exasol/exasol-driver-go/pkg/connection/wsconn"
+	"github.com/exasol/exasol-driver-go/pkg/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type WebsocketTestSuite struct {
+	suite.Suite
+	websocketMock *wsconn.WebsocketConnectionMock
+}
+
+func TestWebsocketSuite(t *testing.T) {
+	suite.Run(t, new(WebsocketTestSuite))
+}
+
+func (suite *WebsocketTestSuite) SetupTest() {
+	suite.websocketMock = wsconn.CreateWebsocketConnectionMock()
+}
+
+func (suite *WebsocketTestSuite) TestSendSuccess() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.SimulateOKResponse(request, types.PublicKeyResponse{PublicKeyPem: "pem"})
+
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.NoError(err)
+	suite.Equal("pem", response.PublicKeyPem)
+}
+
+func (suite *WebsocketTestSuite) TestSendSuccessWithCompression() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteCompressedMessage([]byte(`{"command":"login","protocolVersion":0,"attributes":{}}`), nil)
+	suite.websocketMock.OnReadCompressedMessage([]byte(`{"status":"ok","responseData":{"publicKeyPem":"pem"}}`), nil)
+
+	conn := suite.createOpenConnection()
+	conn.Config.Compression = true
+	err := conn.Send(context.Background(), request, response)
+	suite.NoError(err)
+	suite.Equal("pem", response.PublicKeyPem)
+}
+
+func (suite *WebsocketTestSuite) TestSendWithCompressionFailsDuringUncompress() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteCompressedMessage([]byte(`{"command":"login","protocolVersion":0,"attributes":{}}`), nil)
+	suite.websocketMock.OnReadTextMessage([]byte("invalid gzip content"), nil)
+
+	conn := suite.createOpenConnection()
+	conn.Config.Compression = true
+	err := conn.Send(context.Background(), request, response)
+	suite.EqualError(err, driver.ErrBadConn.Error())
+}
+
+func (suite *WebsocketTestSuite) TestSendSuccessNoResponse() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	suite.websocketMock.SimulateOKResponse(request, types.PublicKeyResponse{PublicKeyPem: "pem"})
+
+	err := suite.createOpenConnection().Send(context.Background(), request, nil)
+	suite.NoError(err)
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsNotConnected() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+
+	conn := suite.createOpenConnection()
+	conn.websocket = nil
+	err := conn.Send(context.Background(), request, response)
+	suite.EqualError(err, `E-EGOD-29: could not send request '{"command":"login","protocolVersion":0,"attributes":{}}': not connected to server`)
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsAtWriteMessage() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteAnyMessage(fmt.Errorf("mock error"))
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.EqualError(err, driver.ErrBadConn.Error())
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsAtReadMessage() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteAnyMessage(nil)
+	suite.websocketMock.OnReadTextMessage(nil, fmt.Errorf("mock error"))
+
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.EqualError(err, driver.ErrBadConn.Error())
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsAtDecodingResponse() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteAnyMessage(nil)
+	suite.websocketMock.OnReadTextMessage([]byte("invalid json"), nil)
+
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.EqualError(err, driver.ErrBadConn.Error())
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsAtNonOKStatusException() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.SimulateErrorResponse(request, mockException)
+
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.EqualError(err, "E-EGOD-11: execution failed with SQL error code 'mock sql code' and message 'mock error'")
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsAtNonOKStatusMissingException() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteTextMessage(wsconn.JsonMarshall(request), nil)
+	suite.websocketMock.OnReadTextMessage([]byte(`{"status": "notok"}`), nil)
+
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.EqualError(err, `result status is not 'ok': "notok", expected exception in response &{notok [] <nil>}`)
+}
+
+func (suite *WebsocketTestSuite) TestSendFailsAtParsingResponseData() {
+	request := types.LoginCommand{Command: types.Command{Command: "login"}}
+	response := &types.PublicKeyResponse{}
+	suite.websocketMock.OnWriteTextMessage(wsconn.JsonMarshall(request), nil)
+	suite.websocketMock.OnReadTextMessage([]byte(`{"status": "ok", "responseData": "invalid"}`), nil)
+
+	err := suite.createOpenConnection().Send(context.Background(), request, response)
+	suite.EqualError(err, `failed to parse response data "\"invalid\"": json: cannot unmarshal string into Go value of type types.PublicKeyResponse`)
+}
+
+func (suite *WebsocketTestSuite) createOpenConnection() *Connection {
+	conn := &Connection{
+		Config:    &config.Config{Host: "invalid", Port: 12345, User: "user", Password: "password", ApiVersion: 42},
+		Ctx:       context.Background(),
+		IsClosed:  false,
+		websocket: suite.websocketMock,
+	}
+	return conn
+}

--- a/pkg/connection/wsconn/wsconn.go
+++ b/pkg/connection/wsconn/wsconn.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -66,7 +67,7 @@ func CreateConnection(ctx context.Context, skipVerify bool, expectedFingerprint 
 	}
 	ws, _, err := dialer.DialContext(ctx, url.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to connect to URL %q: %w", url.String(), err)
 	}
 	ws.EnableWriteCompression(false)
 	return &wsConnImpl{socket: ws}, nil

--- a/pkg/connection/wsconn/wsconn.go
+++ b/pkg/connection/wsconn/wsconn.go
@@ -31,7 +31,7 @@ type wsConnImpl struct {
 }
 
 var cipherSuites = []uint16{
-	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, // Workaround, set db suit in first place to fix handshake issue
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, // Workaround, set db suite in first place to fix handshake issue
 	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 	tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
 	tls.TLS_RSA_WITH_AES_128_CBC_SHA,

--- a/pkg/connection/wsconn/wsconn.go
+++ b/pkg/connection/wsconn/wsconn.go
@@ -1,0 +1,116 @@
+package wsconn
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/exasol/exasol-driver-go/pkg/errors"
+	"github.com/gorilla/websocket"
+)
+
+type WebsocketConnection interface {
+	Close() error
+	EnableWriteCompression(enable bool)
+	WriteMessage(messageType int, data []byte) error
+	ReadMessage() (messageType int, p []byte, err error)
+}
+
+type wsConnImpl struct {
+	socket *websocket.Conn
+}
+
+func CreateConnection(ctx context.Context, skipVerify bool, expectedFingerprint string, url url.URL) (WebsocketConnection, error) {
+	dialer := *websocket.DefaultDialer
+	dialer.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: skipVerify, //nolint:gosec
+		CipherSuites: []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, // Workaround, set db suit in first place to fix handshake issue
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+
+			tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_CHACHA20_POLY1305_SHA256,
+
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+		},
+		VerifyPeerCertificate: certificateVerifier(expectedFingerprint),
+	}
+	ws, _, err := dialer.DialContext(ctx, url.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return &wsConnImpl{socket: ws}, nil
+}
+
+func (ws *wsConnImpl) EnableWriteCompression(enable bool) {
+	if ws.socket == nil {
+		panic(fmt.Errorf("EnableWriteCompression: websocket not available"))
+	}
+	ws.socket.EnableWriteCompression(enable)
+}
+
+func (ws *wsConnImpl) WriteMessage(messageType int, data []byte) error {
+	if ws.socket == nil {
+		return fmt.Errorf("WriteMessage: websocket not available")
+	}
+	return ws.socket.WriteMessage(messageType, data)
+}
+
+func (ws *wsConnImpl) ReadMessage() (messageType int, p []byte, err error) {
+	if ws.socket == nil {
+		return 0, nil, fmt.Errorf("ReadMessage: websocket not available")
+	}
+	return ws.socket.ReadMessage()
+}
+
+func (ws *wsConnImpl) Close() error {
+	if ws.socket == nil {
+		return fmt.Errorf("Close: websocket not available")
+	}
+	return ws.socket.Close()
+}
+
+func certificateVerifier(expectedFingerprint string) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(expectedFingerprint) == 0 {
+			return nil
+		}
+		if len(rawCerts) == 0 {
+			return errors.ErrMissingServerCertificate
+		}
+		actualFingerprint := sha256Hex(rawCerts[0])
+		if !strings.EqualFold(expectedFingerprint, actualFingerprint) {
+			return errors.NewErrCertificateFingerprintMismatch(actualFingerprint, expectedFingerprint)
+		}
+		return nil
+	}
+}
+
+func sha256Hex(data []byte) string {
+	sha256Sum := sha256.Sum256(data)
+	return bytesToHexString(sha256Sum[:])
+}
+
+func bytesToHexString(data []byte) string {
+	return hex.EncodeToString(data)
+}

--- a/pkg/connection/wsconn/wsconn.go
+++ b/pkg/connection/wsconn/wsconn.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
-	"fmt"
 	"net/url"
 	"strings"
 
@@ -14,82 +13,78 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// WebsocketConnection is a thin wrapper around [websocket.Conn]
+// that allows mocking a websocket connection during unit tests.
 type WebsocketConnection interface {
-	Close() error
-	EnableWriteCompression(enable bool)
+	// WriteMessage is a helper method for getting a writer using NextWriter,
+	// writing the message and closing the writer.
 	WriteMessage(messageType int, data []byte) error
+	// ReadMessage is a helper method for getting a reader using NextReader and
+	// reading from that reader to a buffer.
 	ReadMessage() (messageType int, p []byte, err error)
+	// Close closes the underlying network connection without sending or waiting for a close message.
+	Close() error
 }
 
 type wsConnImpl struct {
 	socket *websocket.Conn
 }
 
+var cipherSuites = []uint16{
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, // Workaround, set db suit in first place to fix handshake issue
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+
+	tls.TLS_AES_128_GCM_SHA256,
+	tls.TLS_AES_256_GCM_SHA384,
+	tls.TLS_CHACHA20_POLY1305_SHA256,
+
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+}
+
+// CreateConnection creates a websocket connection to the given URL.
+// This deactivates write compression for the new connection.
 func CreateConnection(ctx context.Context, skipVerify bool, expectedFingerprint string, url url.URL) (WebsocketConnection, error) {
 	dialer := *websocket.DefaultDialer
 	dialer.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: skipVerify, //nolint:gosec
-		CipherSuites: []uint16{
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, // Workaround, set db suit in first place to fix handshake issue
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-
-			tls.TLS_AES_128_GCM_SHA256,
-			tls.TLS_AES_256_GCM_SHA384,
-			tls.TLS_CHACHA20_POLY1305_SHA256,
-
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
-		},
+		InsecureSkipVerify:    skipVerify, //nolint:gosec
+		CipherSuites:          cipherSuites,
 		VerifyPeerCertificate: certificateVerifier(expectedFingerprint),
 	}
 	ws, _, err := dialer.DialContext(ctx, url.String(), nil)
 	if err != nil {
 		return nil, err
 	}
+	ws.EnableWriteCompression(false)
 	return &wsConnImpl{socket: ws}, nil
 }
 
-func (ws *wsConnImpl) EnableWriteCompression(enable bool) {
-	if ws.socket == nil {
-		panic(fmt.Errorf("EnableWriteCompression: websocket not available"))
-	}
-	ws.socket.EnableWriteCompression(enable)
-}
-
 func (ws *wsConnImpl) WriteMessage(messageType int, data []byte) error {
-	if ws.socket == nil {
-		return fmt.Errorf("WriteMessage: websocket not available")
-	}
 	return ws.socket.WriteMessage(messageType, data)
 }
 
 func (ws *wsConnImpl) ReadMessage() (messageType int, p []byte, err error) {
-	if ws.socket == nil {
-		return 0, nil, fmt.Errorf("ReadMessage: websocket not available")
-	}
 	return ws.socket.ReadMessage()
 }
 
 func (ws *wsConnImpl) Close() error {
-	if ws.socket == nil {
-		return fmt.Errorf("Close: websocket not available")
-	}
 	return ws.socket.Close()
 }
 
+// certificateVerifier returns a function that verifies that a certificate has the given fingerprint.
 func certificateVerifier(expectedFingerprint string) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		if len(expectedFingerprint) == 0 {

--- a/pkg/connection/wsconn/wsconn_i_test.go
+++ b/pkg/connection/wsconn/wsconn_i_test.go
@@ -1,0 +1,74 @@
+package wsconn_test
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/exasol/exasol-driver-go/pkg/connection/wsconn"
+	"github.com/exasol/exasol-driver-go/pkg/integrationTesting"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/suite"
+)
+
+type WebsocketITestSuite struct {
+	suite.Suite
+	exasol *integrationTesting.DbTestSetup
+}
+
+func TestIntegrationWebsocketSuite(t *testing.T) {
+	suite.Run(t, new(WebsocketITestSuite))
+}
+
+func (suite *WebsocketITestSuite) SetupSuite() {
+	suite.exasol = integrationTesting.StartDbSetup(&suite.Suite)
+}
+
+func (suite *WebsocketITestSuite) TearDownSuite() {
+	suite.exasol.StopDb()
+}
+
+func (suite *WebsocketITestSuite) TestCreateConnectionSuccess() {
+	conn, err := wsconn.CreateConnection(context.Background(), true, "", suite.exasol.GetUrl())
+	suite.NoError(err)
+	suite.NotNil(conn)
+	conn.Close()
+}
+
+func (suite *WebsocketITestSuite) TestCreateConnectionFailed() {
+	conn, err := wsconn.CreateConnection(context.Background(), true, "", url.URL{Scheme: "wss", Host: "invalid:12345"})
+	suite.EqualError(err, `failed to connect to URL "wss://invalid:12345": dial tcp: lookup invalid: no such host`)
+	suite.Nil(conn)
+}
+
+func (suite *WebsocketITestSuite) TestCreateConnectionInvalidCertificate() {
+	conn, err := wsconn.CreateConnection(context.Background(), false, "invalid", suite.exasol.GetUrl())
+	suite.ErrorContains(err, `failed to connect to URL "wss://localhost:60692": tls: failed to verify certificate`)
+	suite.Nil(conn)
+}
+
+func (suite *WebsocketITestSuite) TestWrite() {
+	conn := suite.createConnection()
+	err := conn.WriteMessage(websocket.TextMessage, []byte("hello"))
+	suite.NoError(err)
+}
+
+func (suite *WebsocketITestSuite) TestRead() {
+	conn := suite.createConnection()
+	conn.WriteMessage(websocket.TextMessage, []byte(`{"command": "login", "protocolVersion": 3}`))
+	messageType, data, err := conn.ReadMessage()
+	suite.Equal(1, messageType)
+	suite.Contains(string(data), `{"status":"ok","responseData"`)
+	suite.NoError(err)
+}
+
+func (suite *WebsocketITestSuite) createConnection() wsconn.WebsocketConnection {
+	conn, err := wsconn.CreateConnection(context.Background(), true, "", suite.exasol.GetUrl())
+	if err != nil {
+		suite.FailNowf("connection failed: %v", err.Error())
+	}
+	suite.T().Cleanup(func() {
+		conn.Close()
+	})
+	return conn
+}

--- a/pkg/connection/wsconn/wsconn_i_test.go
+++ b/pkg/connection/wsconn/wsconn_i_test.go
@@ -2,6 +2,7 @@ package wsconn_test
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -37,13 +38,13 @@ func (suite *WebsocketITestSuite) TestCreateConnectionSuccess() {
 
 func (suite *WebsocketITestSuite) TestCreateConnectionFailed() {
 	conn, err := wsconn.CreateConnection(context.Background(), true, "", url.URL{Scheme: "wss", Host: "invalid:12345"})
-	suite.EqualError(err, `failed to connect to URL "wss://invalid:12345": dial tcp: lookup invalid: no such host`)
+	suite.ErrorContains(err, `failed to connect to URL "wss://invalid:12345": dial tcp`)
 	suite.Nil(conn)
 }
 
 func (suite *WebsocketITestSuite) TestCreateConnectionInvalidCertificate() {
 	conn, err := wsconn.CreateConnection(context.Background(), false, "invalid", suite.exasol.GetUrl())
-	suite.ErrorContains(err, `failed to connect to URL "wss://localhost:60692": tls: failed to verify certificate`)
+	suite.ErrorContains(err, fmt.Sprintf(`failed to connect to URL "wss://%s:%d": tls: failed to verify certificate`, suite.exasol.ConnectionInfo.Host, suite.exasol.ConnectionInfo.Port))
 	suite.Nil(conn)
 }
 

--- a/pkg/connection/wsconn/wsconn_mock.go
+++ b/pkg/connection/wsconn/wsconn_mock.go
@@ -1,0 +1,83 @@
+package wsconn
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/exasol/exasol-driver-go/pkg/types"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/mock"
+)
+
+type WebsocketConnectionMock struct {
+	mock.Mock
+}
+
+func CreateWebsocketConnectionMock() *WebsocketConnectionMock {
+	return &WebsocketConnectionMock{}
+}
+
+func (mock *WebsocketConnectionMock) SimulateSQLQueriesResponse(request interface{}, results []types.SqlQueryResponseResultSet) {
+	marshalledResults := []json.RawMessage{}
+	for _, r := range results {
+		marshalledResults = append(marshalledResults, JsonMarshall(r))
+	}
+	mock.SimulateResponse(request, baseOKResponse(types.SqlQueriesResponse{NumResults: len(results), Results: marshalledResults}))
+}
+func (mock *WebsocketConnectionMock) SimulateOKResponse(request interface{}, response interface{}) {
+	mock.SimulateResponse(request, baseOKResponse(response))
+}
+
+func baseOKResponse(payload interface{}) types.BaseResponse {
+	return types.BaseResponse{Status: "ok", ResponseData: JsonMarshall(payload)}
+}
+
+func JsonMarshall(payload interface{}) json.RawMessage {
+	data, err := json.Marshal(payload)
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal data %v: %w", payload, err))
+	}
+	return data
+}
+
+func (mock *WebsocketConnectionMock) SimulateResponse(request interface{}, response interface{}) {
+	requestMessage := JsonMarshall(request)
+	mock.OnWriteTextMessage(requestMessage, nil)
+	var responseMessage []byte
+	if response != nil {
+		responseMessage = JsonMarshall(response)
+		mock.OnReadTextMessage(responseMessage, nil)
+	}
+	log.Printf("Simulate request: %s -> response: %s", string(requestMessage), string(responseMessage))
+}
+
+func (mock *WebsocketConnectionMock) OnWriteTextMessage(data []byte, returnedError error) {
+	mock.On("WriteMessage", websocket.TextMessage, data).Return(returnedError).Once()
+}
+
+func (mock *WebsocketConnectionMock) OnReadTextMessage(data []byte, returnedError error) {
+	mock.On("ReadMessage").Return(websocket.TextMessage, data, returnedError).Once()
+}
+
+func (mock *WebsocketConnectionMock) OnClose(returnedError error) {
+	mock.On("Close").Return(returnedError)
+}
+
+func (mock *WebsocketConnectionMock) WriteMessage(messageType int, data []byte) error {
+	log.Printf("ws.WriteMessage(%d, `%s`)", messageType, string(data))
+	mockArgs := mock.Called(messageType, data)
+	return mockArgs.Error(0)
+}
+
+func (mock *WebsocketConnectionMock) ReadMessage() (messageType int, response []byte, err error) {
+	mockArgs := mock.Called()
+	responseData := mockArgs.Get(1).([]byte)
+	log.Printf("ws.ReadMessage() -> `%s`", string(responseData))
+	return mockArgs.Int(0), responseData, mockArgs.Error(2)
+}
+
+func (mock *WebsocketConnectionMock) Close() error {
+	mockArgs := mock.Called()
+	return mockArgs.Error(0)
+}

--- a/pkg/connection/wsconn/wsconn_mock.go
+++ b/pkg/connection/wsconn/wsconn_mock.go
@@ -18,19 +18,24 @@ func CreateWebsocketConnectionMock() *WebsocketConnectionMock {
 	return &WebsocketConnectionMock{}
 }
 
-func (mock *WebsocketConnectionMock) SimulateSQLQueriesResponse(request interface{}, results []types.SqlQueryResponseResultSet) {
-	marshalledResults := []json.RawMessage{}
-	for _, r := range results {
-		marshalledResults = append(marshalledResults, JsonMarshall(r))
-	}
-	mock.SimulateResponse(request, baseOKResponse(types.SqlQueriesResponse{NumResults: len(results), Results: marshalledResults}))
+func (mock *WebsocketConnectionMock) SimulateSQLQueriesResponse(request interface{}, results interface{}) {
+	mock.SimulateResponse(request, baseOKResponse(types.SqlQueriesResponse{NumResults: 1, Results: []json.RawMessage{JsonMarshall(results)}}))
 }
+
 func (mock *WebsocketConnectionMock) SimulateOKResponse(request interface{}, response interface{}) {
 	mock.SimulateResponse(request, baseOKResponse(response))
 }
 
+func (mock *WebsocketConnectionMock) SimulateErrorResponse(request interface{}, exception types.Exception) {
+	mock.SimulateResponse(request, baseErrorResponse(exception))
+}
+
 func baseOKResponse(payload interface{}) types.BaseResponse {
 	return types.BaseResponse{Status: "ok", ResponseData: JsonMarshall(payload)}
+}
+
+func baseErrorResponse(exception types.Exception) types.BaseResponse {
+	return types.BaseResponse{Status: "notok", Exception: &exception}
 }
 
 func JsonMarshall(payload interface{}) json.RawMessage {

--- a/pkg/connection/wsconn/wsconn_test.go
+++ b/pkg/connection/wsconn/wsconn_test.go
@@ -1,10 +1,8 @@
-package connection
+package wsconn
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/exasol/exasol-driver-go/internal/config"
 
 	"github.com/stretchr/testify/suite"
 )
@@ -39,8 +37,8 @@ func (suite *WebsocketTestSuite) TestVerifyPeerCertificate() {
 		{[][]byte{[]byte("certificateContent\n")}, noFingerprint, ""},
 	} {
 		suite.Run(fmt.Sprintf("Test %v: rawCerts=%q expectedFingerprint=%q", i, testCase.certificate, testCase.fingerprint), func() {
-			connection := Connection{Config: &config.Config{CertificateFingerprint: testCase.fingerprint}}
-			err := connection.verifyPeerCertificate(testCase.certificate, nil)
+			verifier := certificateVerifier(testCase.fingerprint)
+			err := verifier(testCase.certificate, nil)
 			if testCase.expectedError == "" {
 				suite.NoError(err)
 			} else {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -10,7 +10,7 @@ import (
 var (
 	ErrInvalidConn              = NewDriverErr(exaerror.New("E-EGOD-1").Message("invalid connection"))
 	ErrClosed                   = NewDriverErr(exaerror.New("E-EGOD-2").Message("connection was closed"))
-	ErrMalformedData            = NewDriverErr(exaerror.New("E-EGOD-3").Message("malformed result"))
+	ErrMalformedData            = NewDriverErr(exaerror.New("E-EGOD-3").Message("malformed empty result"))
 	ErrAutocommitEnabled        = NewDriverErr(exaerror.New("E-EGOD-4").Message("begin not working when autocommit is enabled"))
 	ErrInvalidValuesCount       = NewDriverErr(exaerror.New("E-EGOD-5").Message("invalid value count for prepared status"))
 	ErrNoLastInsertID           = NewDriverErr(exaerror.New("E-EGOD-6").Message("no LastInsertId available"))
@@ -87,9 +87,10 @@ func NewUncompressingError(err error) DriverErr {
 		Parameter("error", err))
 }
 
-func NewJsonDecodingError(err error) DriverErr {
+func NewJsonDecodingError(err error, message []byte) DriverErr {
 	return NewDriverErr(exaerror.New("W-EGOD-19").
-		Message("could not decode json data: {{error}}").
+		Message("could not decode json data {{data}}: {{error}}").
+		Parameter("data", string(message)).
 		Parameter("error", err))
 }
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -140,6 +140,12 @@ func NewCouldNotGetOsUser(err error) DriverErr {
 		Parameter("error", err))
 }
 
+func NewWebsocketNotConnected(request interface{}) DriverErr {
+	return NewDriverErr(exaerror.New("E-EGOD-29").
+		Message("could not send request {{request}}: not connected to server").
+		Parameter("request", request))
+}
+
 // DriverErr This type represents an error that can occur when working with a database connection.
 type DriverErr string
 

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -31,7 +31,7 @@ func (suite *ErrorsTestSuite) TestErrClosed() {
 }
 
 func (suite *ErrorsTestSuite) TestErrMalformedData() {
-	suite.EqualError(ErrMalformedData, "E-EGOD-3: malformed result")
+	suite.EqualError(ErrMalformedData, "E-EGOD-3: malformed empty result")
 }
 
 func (suite *ErrorsTestSuite) TestErrAutocommitEnabled() {
@@ -94,7 +94,7 @@ func (suite *ErrorsTestSuite) TestLogUncompressingError() {
 }
 
 func (suite *ErrorsTestSuite) TestLogJsonDecodingError() {
-	suite.EqualError(NewJsonDecodingError(fmt.Errorf("error")), "W-EGOD-19: could not decode json data: 'error'")
+	suite.EqualError(NewJsonDecodingError(fmt.Errorf("error"), []byte("data")), "W-EGOD-19: could not decode json data 'data': 'error'")
 }
 
 func (suite *ErrorsTestSuite) TestNewInvalidConnectionStringInvalidPort() {

--- a/pkg/integrationTesting/dbTestSetup.go
+++ b/pkg/integrationTesting/dbTestSetup.go
@@ -1,0 +1,59 @@
+package integrationTesting
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	testSetupAbstraction "github.com/exasol/exasol-test-setup-abstraction-server/go-client"
+	"github.com/stretchr/testify/suite"
+)
+
+const defaultExasolDbVersion = "8.22.0"
+
+type DbTestSetup struct {
+	suite          *suite.Suite
+	Exasol         *testSetupAbstraction.TestSetupAbstraction
+	ConnectionInfo *testSetupAbstraction.ConnectionInfo
+}
+
+func StartDbSetup(suite *suite.Suite) *DbTestSetup {
+	if testing.Short() {
+		suite.T().Skip()
+	}
+	exasolDbVersion := getDbVersion()
+	suite.T().Logf("Starting Exasol %s...", exasolDbVersion)
+	exasol, err := testSetupAbstraction.New().DockerDbVersion(exasolDbVersion).Start()
+	if err != nil {
+		suite.FailNowf("failed to create test setup abstraction: %v", err.Error())
+	}
+	connectionInfo, err := exasol.GetConnectionInfo()
+	if err != nil {
+		suite.FailNowf("error getting connection info: %v", err.Error())
+	}
+	setup := DbTestSetup{suite: suite, Exasol: exasol, ConnectionInfo: connectionInfo}
+	return &setup
+}
+
+func getDbVersion() string {
+	dbVersion := os.Getenv("DB_VERSION")
+	if dbVersion != "" {
+		return dbVersion
+	}
+	return defaultExasolDbVersion
+}
+
+// hostAndPort returns a string with host and port
+func (setup *DbTestSetup) hostAndPort() string {
+	return fmt.Sprintf("%s:%d", setup.ConnectionInfo.Host, setup.ConnectionInfo.Port)
+}
+
+// HostAndPort returns a string with host and port
+func (setup *DbTestSetup) GetUrl() url.URL {
+	return url.URL{Scheme: "wss", Host: setup.hostAndPort()}
+}
+
+func (setup *DbTestSetup) StopDb() {
+	setup.suite.NoError(setup.Exasol.Stop())
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.exclusions=*_test.go,examples/**
 sonar.tests=.
 sonar.test.inclusions=*_test.go
 sonar.go.coverage.reportPaths=./coverage.out
-sonar.coverage.exclusions=itest/integration_test.go,**/*_test.go
+sonar.coverage.exclusions=**/*_test.go,**/*_mock.go,pkg/integrationTesting/**


### PR DESCRIPTION
This refactors the Websocket connection to allow mocking it during unit tests to improve test coverage.

Closes #95