### PR TITLE
Removed debug output

### DIFF
--- a/.github/workflows/broken_links_checker.yml
+++ b/.github/workflows/broken_links_checker.yml
@@ -15,7 +15,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure broken links checker
         run: |
           mkdir -p ./target
@@ -27,6 +27,6 @@ jobs:
                ']}' > ./target/broken_links_checker.json
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          use-quiet-mode: 'yes'
-          use-verbose-mode: 'yes'
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
           config-file: ./target/broken_links_checker.json

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,9 @@ jobs:
             ${{ runner.os }}-go-${{ matrix.go }}
             ${{ runner.os }}-go-
 
+      - name: Enable testcontainer reuse
+       run: echo 'testcontainers.reuse.enable=true' > "$HOME/.testcontainers.properties"
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Enable testcontainer reuse
-       run: echo 'testcontainers.reuse.enable=true' > "$HOME/.testcontainers.properties"
+        run: echo 'testcontainers.reuse.enable=true' > "$HOME/.testcontainers.properties"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}-go-${{ matrix.go }}-db-${{ matrix.db }}
       cancel-in-progress: true
     name: Build with go version ${{ matrix.go }} and db ${{ matrix.db }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up Go
         uses: actions/setup-go@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         go: ["1.20", "1.21"]
-        db: ["7.1.22", "8.22.0"]
+        db: ["7.1.23", "8.22.0"]
     env:
       DEFAULT_GO: "1.21"
       DEFAULT_DB: "8.22.0"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
         run: go test -v -count 1 -coverprofile=coverage.out ./...
 
       - name: SonarCloud Scan
-        if: matrix.go == env.DEFAULT_GO && matrix.db == env.DEFAULT_DB && github.repository_owner == 'exasol'
+        if: matrix.go == env.DEFAULT_GO && matrix.db == env.DEFAULT_DB && github.repository_owner == 'exasol' && env.SONAR_TOKEN != null
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/project-keeper-verify.yml
+++ b/.github/workflows/project-keeper-verify.yml
@@ -14,7 +14,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/project-keeper.sh
+++ b/.github/workflows/project-keeper.sh
@@ -5,7 +5,7 @@ set -o nounset
 set -o pipefail
 
 readonly pk_mode="${1-verify}";
-readonly version="2.9.11"
+readonly version="2.9.12"
 
 readonly pk_jar="$HOME/.m2/repository/com/exasol/project-keeper-cli/$version/project-keeper-cli-$version.jar"
 

--- a/.project-keeper.yml
+++ b/.project-keeper.yml
@@ -1,4 +1,4 @@
 sources:
   - type: golang
     path: go.mod
-version: 1.0.2
+version: 1.0.3

--- a/dependencies.md
+++ b/dependencies.md
@@ -24,4 +24,4 @@
 [3]: https://github.com/stretchr/testify/blob/v1.8.4/LICENSE
 [4]: https://github.com/go-yaml/yaml/blob/v3.0.1/LICENSE
 [5]: https://github.com/uber-go/goleak/blob/HEAD/LICENSE
-[6]: https://cs.opensource.google/go/x/sync/+/v0.3.0:LICENSE
+[6]: https://cs.opensource.google/go/x/sync/+/v0.4.0:LICENSE

--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [1.0.3](changes_1.0.3.md)
 * [1.0.2](changes_1.0.2.md)
 * [1.0.1](changes_1.0.1.md)
 * [1.0.0](changes_1.0.0.md)

--- a/doc/changes/changes_1.0.3.md
+++ b/doc/changes/changes_1.0.3.md
@@ -1,0 +1,16 @@
+# Exasol Driver go 1.0.3, released 2023-10-11
+
+Code name: Reduce log verbosity
+
+## Summary
+
+This release reduces log verbosity.
+
+## Features
+
+* #97: Reduced log verbosity
+## Dependency Updates
+
+### Test Dependency Updates
+
+* Updated `golang.org/x/sync:v0.3.0` to `v0.4.0`

--- a/doc/changes/changes_1.0.3.md
+++ b/doc/changes/changes_1.0.3.md
@@ -8,7 +8,8 @@ This release reduces log verbosity.
 
 ## Features
 
-* #97: Reduced log verbosity
+* #97: Reduced log verbosity (contributed by [@sabitor](https://github.com/sabitor))
+
 ## Dependency Updates
 
 ### Test Dependency Updates

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/stretchr/testify v1.8.4
 	go.uber.org/goleak v1.2.1
-	golang.org/x/sync v0.3.0
+	golang.org/x/sync v0.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -18,5 +18,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect
-	golang.org/x/net v0.14.0 // indirect
+	golang.org/x/net v0.17.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -31,11 +31,11 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
 go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
-golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
-golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
-golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
-golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/sync v0.4.0 h1:zxkM55ReGkDlKSM+Fu41A+zmbZuaPVbGMzvvdUPznYQ=
+golang.org/x/sync v0.4.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
+golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const DriverVersion = "v1.0.2"
+const DriverVersion = "v1.0.3"

--- a/itest/integration_test.go
+++ b/itest/integration_test.go
@@ -60,10 +60,6 @@ func (suite *IntegrationTestSuite) TestConnect() {
 	suite.Equal("2", columns[0])
 }
 
-func (suite *IntegrationTestSuite) isExasol7_0_x() bool {
-	return strings.HasPrefix(suite.exasol.DbVersion, "7.0.")
-}
-
 func (suite *IntegrationTestSuite) TestConnection() {
 	actualFingerprint := suite.getActualCertificateFingerprint()
 	const wrongFingerprint = "wrongFingerprint"
@@ -71,13 +67,7 @@ func (suite *IntegrationTestSuite) TestConnection() {
 
 	errorMsgWrongFingerprint := fmt.Sprintf("E-EGOD-10: the server's certificate fingerprint '%s' does not match the expected fingerprint '%s'", actualFingerprint, wrongFingerprint)
 	const errorMsgAuthFailed = "E-EGOD-11: execution failed with SQL error code '08004' and message 'Connection exception - authentication failed.'"
-
-	var errorMsgTokenAuthFailed string
-	if suite.isExasol7_0_x() {
-		errorMsgTokenAuthFailed = "E-EGOD-11: execution failed with SQL error code '00000' and message 'Invalid login request command: loginToken'"
-	} else {
-		errorMsgTokenAuthFailed = "E-EGOD-11: execution failed with SQL error code '08004' and message 'Connection exception - authentication failed'"
-	}
+	const errorMsgTokenAuthFailed = "E-EGOD-11: execution failed with SQL error code '08004' and message 'Connection exception - authentication failed'"
 
 	var errorMsgCertWrongHost string
 	if suite.host == "localhost" {

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
-	"log"
 	"math/big"
 	"os/user"
 	"runtime"
@@ -279,7 +278,6 @@ func (c *Connection) SimpleExec(ctx context.Context, query string) (*types.SqlQu
 }
 
 func (c *Connection) close(ctx context.Context) error {
-	log.Printf("Closing connection")
 	c.IsClosed = true
 	err := c.Send(ctx, &types.Command{Command: "disconnect"}, nil)
 	closeError := c.websocket.Close()


### PR DESCRIPTION
While using the Exasol Go driver I realized that there is a log message which gets printed out to stdout every time when I close the Exasol connection, which is not desirable.
I removed that line in the close function to prevent this extra log output.

Closes #97