### PR TITLE
Prepare release 1.1.1

### DIFF
--- a/doc/changes/changes_1.1.1.md
+++ b/doc/changes/changes_1.1.1.md
@@ -1,4 +1,4 @@
-# Exasol Driver go 1.1.1, released 2026-??-??
+# Exasol Driver go 1.1.1, released 2026-09-11
 
 Code name: Serialize WebSocket access and fix local IMPORT
 


### PR DESCRIPTION
Updated release date for Exasol Driver go 1.1.1.